### PR TITLE
Update extension for Chrome MV3

### DIFF
--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -1,7 +1,13 @@
 /* global chrome */
 
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.action.disable();
+});
+
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
-  if (tab.url.indexOf('.strava.com') > -1) {
-    chrome.pageAction.show(tabId);
+  if (tab.url && tab.url.indexOf('.strava.com') > -1) {
+    chrome.action.enable(tabId);
+  } else {
+    chrome.action.disable(tabId);
   }
 });

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,13 +1,10 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Strava Enhancement Suite",
   "description": "Handy tools and improvements to Strava.com",
   "version": "23.6.6.1856",
   "background": {
-    "scripts": [
-      "js/libs/browser-polyfill.js",
-      "js/background.js"
-    ]
+    "service_worker": "js/background.js"
   },
   "content_scripts": [
     {
@@ -28,21 +25,32 @@
     "128": "icons/icon128.png"
   },
   "options_page": "pages/options.html",
-  "page_action": {
-    "default_icon": "icons/icon48.png",
+  "action": {
+    "default_icon": {
+      "48": "icons/icon48.png"
+    },
     "default_title": "Strava Enhancement Suite",
     "default_popup": "pages/popup.html"
   },
   "permissions": [
-    "http://*.strava.com/*",
-    "https://*.strava.com/*",
     "storage",
     "tabs"
   ],
+  "host_permissions": [
+    "http://*.strava.com/*",
+    "https://*.strava.com/*"
+  ],
   "web_accessible_resources": [
-    "js/libs/*.js",
-    "js/libs/*.css",
-    "js/main.js",
-    "pages/options.js"
+    {
+      "resources": [
+        "js/libs/*.js",
+        "js/libs/*.css",
+        "js/main.js",
+        "pages/options.js"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- migrate manifest to MV3
- update background script for new `action` API

## Testing
- `npm test` *(fails: ava not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c0a426c4832891238c3c80668d56