### PR TITLE
Update extension for Chrome MV3

### DIFF
--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -1,7 +1,13 @@
 /* global chrome */
 
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.action.disable();
+});
+
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
-  if (tab.url.indexOf('.strava.com') > -1) {
-    chrome.pageAction.show(tabId);
+  if (tab.url && tab.url.indexOf('.strava.com') > -1) {
+    chrome.action.enable(tabId);
+  } else {
+    chrome.action.disable(tabId);
   }
 });

--- a/extension/js/content_script.js
+++ b/extension/js/content_script.js
@@ -15,7 +15,7 @@ function injectJs(what) {
     if (what.startsWith('//')) { // Only for local development, CWS disallows remote code
       el.src = what;
     } else if (what.startsWith('/')) {
-      el.src = chrome.extension.getURL(what);
+      el.src = chrome.runtime.getURL(what);
     } else {
       el.textContent = what;
     }
@@ -30,7 +30,7 @@ function injectJs(what) {
 function injectCss(what) {
   return new Promise((resolve, reject) => {
     const el = document.createElement('link');
-    el.href = chrome.extension.getURL(what);
+    el.href = chrome.runtime.getURL(what);
     el.type = 'text/css';
     el.rel = 'stylesheet';
     el.onerror = reject;
@@ -51,7 +51,7 @@ function StravaEnhancementSuiteInit() {
 }
 
 
-injectJs(StravaEnhancementSuiteInit.toString() + ';StravaEnhancementSuiteInit();');
+injectJs('/js/injected_init.js');
 
 
 // TODO: Add unit tests
@@ -94,7 +94,7 @@ async function executeInstructionsFromUrl() {
 
   await injectJs('/js/main.js');
 
-  await injectJs(`window.strava_enhancement_suite = new StravaEnhancementSuite(jQuery, ${JSON.stringify(options)});`);
+  window.dispatchEvent(new CustomEvent('SES_init', { detail: options }));
 })();
 
 

--- a/extension/js/injected_init.js
+++ b/extension/js/injected_init.js
@@ -1,0 +1,17 @@
+(function() {
+  function StravaEnhancementSuiteInit() {
+    const originalAddEventListener = document.addEventListener;
+    document.addEventListener = function (type, listener, options) {
+      if (type === 'wheel') {
+        console.log('[StravaEnhancementSuiteInit]: Preventing wheel event listener to avoid scroll blocking');
+        return;
+      }
+      return originalAddEventListener.call(document, type, listener, options);
+    };
+  }
+
+  window.addEventListener('SES_init', (e) => {
+    StravaEnhancementSuiteInit();
+    window.strava_enhancement_suite = new StravaEnhancementSuite(jQuery, e.detail);
+  });
+})();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,13 +1,10 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Strava Enhancement Suite",
   "description": "Handy tools and improvements to Strava.com",
   "version": "23.6.6.1856",
   "background": {
-    "scripts": [
-      "js/libs/browser-polyfill.js",
-      "js/background.js"
-    ]
+    "service_worker": "js/background.js"
   },
   "content_scripts": [
     {
@@ -28,21 +25,33 @@
     "128": "icons/icon128.png"
   },
   "options_page": "pages/options.html",
-  "page_action": {
-    "default_icon": "icons/icon48.png",
+  "action": {
+    "default_icon": {
+      "48": "icons/icon48.png"
+    },
     "default_title": "Strava Enhancement Suite",
     "default_popup": "pages/popup.html"
   },
   "permissions": [
-    "http://*.strava.com/*",
-    "https://*.strava.com/*",
     "storage",
     "tabs"
   ],
+  "host_permissions": [
+    "http://*.strava.com/*",
+    "https://*.strava.com/*"
+  ],
   "web_accessible_resources": [
-    "js/libs/*.js",
-    "js/libs/*.css",
-    "js/main.js",
-    "pages/options.js"
+    {
+      "resources": [
+        "js/libs/*.js",
+        "js/libs/*.css",
+        "js/main.js",
+        "js/injected_init.js",
+        "pages/options.js"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- migrate manifest to MV3
- update background script for new `action` API
- use `chrome.runtime.getURL` and event-based initialization to satisfy CSP

## Testing
- `npm test` *(fails: ava not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c0a426c4832891238c3c80668d56